### PR TITLE
Fix JSON structure and remove deprecated key

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,11 +2,6 @@
   "name": "Django Heroku Connect Example",
   "description": "A simple example app for Django and Heroku Connect.",
   "logo": "https://vignette.wikia.nocookie.net/logopedia/images/1/19/Salesforce.svg",
-  "keywords": [
-    "django",
-    "heroku-connect",
-    "postgresql"
-  ],
   "repository": "https://github.com/Thermondo/django-heroku-connect-example-app",
   "success_url": "/",
   "env": {
@@ -30,7 +25,7 @@
       "plan": "heroku-postgresql"
     },
     {
-      "plan": "herokuconnect",
+      "plan": "herokuconnect"
     }
   ],
   "buildpacks": [


### PR DESCRIPTION
Currently, when clicking on "Deploy to Heroku" the users got this error:

> The content of app.json is not valid; please see app.json Schema for more information.

This PR fixes the JSON structure and remove deprecated key (`keywords`).